### PR TITLE
Branch for fetch mission

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.1.1",
@@ -5302,6 +5303,29 @@
       "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -15260,6 +15284,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.1.1",

--- a/src/components/Mission.js
+++ b/src/components/Mission.js
@@ -23,7 +23,34 @@ function Mission() {
   }
   return (
     <div>
-     
+      <table>
+        <thead>
+          <tr>
+            <th>Mission</th>
+            <th>Description</th>
+            <th>Status</th>
+            <th>Take action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {memoizedMissions.map((mission) => (
+            <tr key={mission.id}>
+              <td key={mission.mission_id}>{mission.name}</td>
+              <td key={mission.mission_id}>{mission.description}</td>
+              <td key={mission.mission_id}>
+                {mission.reserved === false ? 'Not A MEMBER' : 'ACTIVE MEMBER'}
+              </td>
+              <td key={mission.mission_id}>
+                {mission.reserved === false ? (
+                  <button type="button">Join Mission</button>
+                ) : (
+                  <button type="button">Leave Mission</button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
 
     </div>
   );

--- a/src/components/Mission.js
+++ b/src/components/Mission.js
@@ -1,4 +1,31 @@
+import { useSelector, useDispatch } from 'react-redux';
+import { useEffect, useMemo } from 'react';
+import {
+  fetchmissions, getError, getLoading, getMissions,
+} from '../redux/missions/missionSlice';
+
 function Mission() {
-  return (<div> this is Mission page </div>);
+  const dispatch = useDispatch();
+  const missions = useSelector(getMissions);
+  const missionLoading = useSelector(getLoading);
+  const missionError = useSelector(getError);
+
+  useEffect(() => {
+    dispatch(fetchmissions());
+  }, [dispatch]);
+  // memoize the missions data and use it to render the component on every navigation change.
+  const memoizedMissions = useMemo(() => missions, [missions]);
+  if (missionLoading === true) {
+    return <div>Loading..</div>;
+  }
+  if (missionError !== '') {
+    return <div>error fetching data</div>;
+  }
+  return (
+    <div>
+     
+
+    </div>
+  );
 }
 export default Mission;

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
 import './index.css';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import store from './redux/store';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>,
+  <Provider store={store}>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+    ,
+  </Provider>,
+
 );

--- a/src/redux/missions/missionSlice.js
+++ b/src/redux/missions/missionSlice.js
@@ -7,7 +7,14 @@ const initialState = {
   isloading: false,
   error: '',
 };
-
+export const fetchmissions = createAsyncThunk('missions/fetchmission', async () => {
+    try {
+      const response = await axios.get(url);
+      return response.data;
+    } catch (error) {
+      return error.message;
+    }
+  });
 const missionSlice = createSlice({
   name: 'missions',
   initialState,

--- a/src/redux/missions/missionSlice.js
+++ b/src/redux/missions/missionSlice.js
@@ -1,0 +1,17 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const url = 'https://api.spacexdata.com/v3/missions';
+const initialState = {
+  missions: [],
+  isloading: false,
+  error: '',
+};
+
+const missionSlice = createSlice({
+  name: 'missions',
+  initialState,
+  reducers: {},
+ 
+});
+export default missionSlice.reducer;

--- a/src/redux/missions/missionSlice.js
+++ b/src/redux/missions/missionSlice.js
@@ -43,4 +43,7 @@ const missionSlice = createSlice({
   },
  
 });
+export const getMissions = (state) => state.missions.missions;
+export const getLoading = (state) => state.missions.isloading;
+export const getError = (state) => state.missions.error;
 export default missionSlice.reducer;

--- a/src/redux/missions/missionSlice.js
+++ b/src/redux/missions/missionSlice.js
@@ -19,6 +19,28 @@ const missionSlice = createSlice({
   name: 'missions',
   initialState,
   reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(fetchmissions.pending, (state) => {
+      state.isloading = true;
+    });
+    builder.addCase(fetchmissions.fulfilled, (state, action) => {
+      state.isloading = false;
+      const allmissions = action.payload;
+      const selectedMission = allmissions.map((mission) => (
+        {
+          id: mission.mission_id,
+          name: mission.mission_name,
+          description: mission.description,
+          reserved: false,
+        }
+      ));
+      state.missions = selectedMission;
+    });
+    builder.addCase(fetchmissions.rejected, (state, action) => {
+      state.isloading = false;
+      state.error = action.error.message;
+    });
+  },
  
 });
 export default missionSlice.reducer;

--- a/src/redux/missions/missionSlice.js
+++ b/src/redux/missions/missionSlice.js
@@ -8,13 +8,13 @@ const initialState = {
   error: '',
 };
 export const fetchmissions = createAsyncThunk('missions/fetchmission', async () => {
-    try {
-      const response = await axios.get(url);
-      return response.data;
-    } catch (error) {
-      return error.message;
-    }
-  });
+  try {
+    const response = await axios.get(url);
+    return response.data;
+  } catch (error) {
+    return error.message;
+  }
+});
 const missionSlice = createSlice({
   name: 'missions',
   initialState,
@@ -41,7 +41,7 @@ const missionSlice = createSlice({
       state.error = action.error.message;
     });
   },
- 
+
 });
 export const getMissions = (state) => state.missions.missions;
 export const getLoading = (state) => state.missions.isloading;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,0 +1,9 @@
+import { configureStore } from '@reduxjs/toolkit';
+import missionReducer from './missions/missionSlice';
+
+const store = configureStore({
+  reducer: {
+    missions: missionReducer,
+  },
+});
+export default store;


### PR DESCRIPTION
In this feature branch, I 
- Fetch data from the Missions endpoint (https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section.
- After  data are fetched, dispatch an action to store the selected data in the Redux store:
     ==> mission_id
     == >mission_name
     ==>description
- only dispatch those actions once and do not add data to store on every re-render (i.e. when changing views / using navigation). by memoizing the mission data and using it to render the component on every navigation change.
-  Render the fetched data in the mission component
-  connect the store with the app using the provider