### PR TITLE
Switch badges for Rockets - Conditional components #25

### DIFF
--- a/src/components/Rockets.js
+++ b/src/components/Rockets.js
@@ -37,7 +37,7 @@ const Rockets = () => {
               )}
               {rocket.description}
             </p>
-            {rocket.reserved ? (
+            {rocket.reserved && (
               <button
                 type="button"
                 className={styles.cancelled}
@@ -45,7 +45,8 @@ const Rockets = () => {
               >
                 Cancel Reservation
               </button>
-            ) : (
+            )}
+            {!rocket.reserved && (
               <button
                 type="button"
                 className={styles.reserve}


### PR DESCRIPTION

In this branch you can find the following features:

Rockets that have already been reserved now show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design)

Used the React conditional rendering syntax:

{rocket.reserved && ( 
    // render Cancel Rocket button
)}